### PR TITLE
chore: bump version to 2.0.6

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -57,6 +57,11 @@ jobs:
           if [ "${{ github.event.inputs.force_release }}" = "true" ]; then
             SHOULD_RELEASE=true
             VERSION_BUMP="patch"
+          # Check for manual version bump commits (should create proper releases)
+          elif echo "$COMMIT_MSG" | grep -qE "^chore:.*bump version to [0-9]+\.[0-9]+\.[0-9]+"; then
+            SHOULD_RELEASE=true
+            VERSION_BUMP="none"  # Version already bumped manually
+            IS_PRERELEASE=false
           # Check for version-bumping commit types
           elif echo "$COMMIT_MSG" | grep -qE "^(feat|fix|perf)(\(.+\))?\!?:"; then
             SHOULD_RELEASE=true
@@ -112,6 +117,10 @@ jobs:
             # Create prerelease version with commit SHA
             SHORT_SHA=$(git rev-parse --short HEAD)
             NEW_VERSION="${CURRENT_VERSION}-dev.${SHORT_SHA}"
+          elif [ "$VERSION_BUMP" = "none" ]; then
+            # Version already bumped manually, use current version
+            NEW_VERSION="$CURRENT_VERSION"
+            VERSION_BUMPED=false
           elif [ "$VERSION_BUMP" != "none" ]; then
             # Calculate what the new version would be (for release naming)
             if [ "$VERSION_BUMP" = "major" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,20 @@
 {
   "name": "foto-recipe-wizard",
+<<<<<<< HEAD
   "version": "2.0.5",
+=======
+  "version": "2.0.4",
+>>>>>>> origin/develop
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foto-recipe-wizard",
+<<<<<<< HEAD
       "version": "2.0.5",
+=======
+      "version": "2.0.4",
+>>>>>>> origin/develop
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foto-recipe-wizard",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Create and apply photo recipes with AI-powered color grading and DNG RAW processing support",
   "main": "dist/main/main.js",
   "scripts": {


### PR DESCRIPTION
Version bump to 2.0.6 with workflow fix for proper releases

This includes:
- Fix for version bump commit detection 
- Assets will now properly appear in downloadable releases instead of prereleases
- Version 2.0.6 ready for full release